### PR TITLE
Fix critical vulnerability in elliptic

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     ]
   },
   "resolutions": {
-    "elliptic": "6.6.1"
+    "elliptic": "6.6.1",
+    "path-to-regexp": "8.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "resolutions": {
+    "elliptic": "6.6.1"
   }
 }


### PR DESCRIPTION
This pull request resolves the critical vulnerability in the `elliptic` package by forcing its version to 6.6.1.